### PR TITLE
deploy clojars via ci

### DIFF
--- a/.github/workflows/deploy-clojars.yml
+++ b/.github/workflows/deploy-clojars.yml
@@ -1,0 +1,31 @@
+name: deploy-clojars
+on: [ workflow_dispatch ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: clojure:openjdk-11-tools-deps
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: clj -Adepstar
+      - uses: actions/upload-artifact@v2
+        with:
+          name: jar
+          path: cruler.jar
+
+  deploy:
+    needs: build-jar
+    runs-on: ubuntu-latest
+    container:
+      image: clojure:openjdk-11-tools-deps
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: jar
+      - name: Deploy
+        env:
+          CLOJARS_USERNAME: ${{ secrets.CLOJARS_USERNAME }}
+          CLOJARS_PASSWORD: ${{ secrets.CLOJARS_PASSWORD }}
+        run: clj -Adeploy

--- a/.github/workflows/deploy-clojars.yml
+++ b/.github/workflows/deploy-clojars.yml
@@ -15,7 +15,7 @@ jobs:
           path: cruler.jar
 
   deploy:
-    needs: build-jar
+    needs: build
     runs-on: ubuntu-latest
     container:
       image: clojure:openjdk-11-tools-deps

--- a/deps.edn
+++ b/deps.edn
@@ -15,4 +15,7 @@
                   :main-opts ["-m" "cognitect.test-runner"]}
            :depstar {:extra-deps {seancorfield/depstar {:mvn/version "1.0.97"}}
                      :main-opts ["-m" "hf.depstar.uberjar" "cruler.jar"
-                                 "-S" "-C" "-m" "cruler.main"]}}}
+                                 "-S" "-C" "-m" "cruler.main"]}
+           :deploy {:extra-deps {slipset/deps-deploy {:mvn/version "RELEASE"
+                                                      :exclusions [ch.qos.logback/logback-classic]}}
+                    :main-opts ["-m" "deps-deploy.deps-deploy" "deploy" "cruler.jar"]}}}

--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,19 @@
   <artifactId>cruler</artifactId>
   <version>1.0.0</version>
   <name>cruler</name>
+  <url>http://github.com/xcoo/cruler</url>
+  <licenses>
+    <license>
+      <name>Apache License, 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+    </license>
+  </licenses>
+  <scm>
+    <url>https://github.com/xcoo/cruler</url>
+    <connection>scm:git:git://github.com/xcoo/cruler.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/xcoo/cruler.git</developerConnection>
+    <tag>HEAD</tag>
+  </scm>
   <dependencies>
     <dependency>
       <groupId>org.clojure</groupId>
@@ -30,6 +43,11 @@
       <groupId>org.clojure</groupId>
       <artifactId>data.csv</artifactId>
       <version>1.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-nop</artifactId>
+      <version>1.7.30</version>
     </dependency>
     <dependency>
       <groupId>clj-commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>cruler</groupId>
+  <groupId>xcoo</groupId>
   <artifactId>cruler</artifactId>
   <version>1.0.0</version>
   <name>cruler</name>


### PR DESCRIPTION
deploy to clojars via GitHub Actions

## What

1. Setup action to deploy `cruler` to clojars using https://github.com/slipset/deps-deploy
1. update `pom.xml` by `clj -Spom` and manually

As example, I created [project](https://github.com/blue0513/clojure-cli-deploy) and setup Actions to deploy clojars. See https://github.com/blue0513/clojure-cli-deploy/actions/runs/472352455 

## Action to deploy after merge
1. set secret: `CLOJARS_USERNAME`, `CLOJARS_PASSWORD`
1. Click `Run workflow` button on Actions page
ref: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
