### PR TITLE
update clj-yaml version

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
         org.clojure/tools.cli {:mvn/version "1.0.194"}
         org.slf4j/slf4j-nop {:mvn/version "1.7.30"}
         clj-commons/pomegranate {:mvn/version "1.2.0"}
-        clj-commons/clj-yaml {:mvn/version "0.7.1"}
+        clj-commons/clj-yaml {:mvn/version "0.7.2"}
         org.clojure/data.csv {:mvn/version "1.0.0"}
         io.aviso/pretty {:mvn/version "0.1.37"}
         phrase {:mvn/version "0.3-alpha4"}}

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>clj-commons</groupId>
       <artifactId>clj-yaml</artifactId>
-      <version>0.7.1</version>
+      <version>0.7.2</version>
     </dependency>
     <dependency>
       <groupId>clj-commons</groupId>


### PR DESCRIPTION
I'd like to use `clj-commons/clj-yaml 0.7.2` in my project. I tried using `:exclusions` in my `project.clj` of leiningen, but I was not able to pick `clj-commons/clj-yaml 0.7.2`. So, I try upgrading the version of `clj-commons/clj-yaml` in cruler.