### PR TITLE
change pprint-str to print-str

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,17 +227,19 @@ Cruler expects validators to return Map. The Map should be as follow.
    :validator.namespace/validator-key ["regex of resource file"]}
  :paths ["validator"]
  :colorize true
+ :format {:error-value :pprint}
  :deps [[library version]]}
 ```
 
 `cruler.edn` requires some keys.
 
-| key           | require | default       | description                                                  |
-| ------------- | ------- | ------------- | ------------------------------------------------------------ |
-| `:validators` | true    |               | Define the validator and resources to be validated           |
-| `:paths`      | false   | ["validator"] | Define the classpaths including validator source codes       |
-| `:colorize`   | false   | true          | Define whether to color the output result                    |
-| `:deps`       | false   | nil           | Define the dependencies which the project require as library |
+| key           | require | default                | description                                                             |
+| ------------- | ------- | ---------------------- | ----------------------------------------------------------------------- |
+| `:validators` | true    |                        | Define the validator and resources to be validated                      |
+| `:paths`      | false   | ["validator"]          | Define the classpaths including validator source codes                  |
+| `:colorize`   | false   | true                   | Define whether to color the output result                               |
+| `:format`     | false   | {:error-value :pprint} | Define an error-value print function. You can use `:pprint` or `:print` |
+| `:deps`       | false   | nil                    | Define the dependencies which the project require as library            |
 
 See [cruler.edn.sample](dev-resources/cruler.edn.sample) and [sample-validator/cruler.edn](dev-resources/sample-validator/cruler.edn) as samples.
 

--- a/dev-resources/cruler.edn.sample
+++ b/dev-resources/cruler.edn.sample
@@ -11,4 +11,7 @@
  ;; Whether to color the output result, the default value is `true`
  ;; :colorize true
 
+ ;; Set an error-value print function, the default value is `pprint`
+ ;; :format {:error-value :pprint}
+
  :deps [[clj-hgvs "0.4.0"]]}

--- a/dev-resources/sample-validator/cruler.edn
+++ b/dev-resources/sample-validator/cruler.edn
@@ -17,4 +17,7 @@
  ;; Whether to color the output result, the default value is `true`
  ;; :colorize true
 
+ ;; Set error-value print function, the default value is `pprint`
+ ;; :format {:error-value :pprint}
+
  :deps [[clj-hgvs "0.4.0"]]}

--- a/dev-resources/sample-validator/cruler.edn
+++ b/dev-resources/sample-validator/cruler.edn
@@ -17,7 +17,7 @@
  ;; Whether to color the output result, the default value is `true`
  ;; :colorize true
 
- ;; Set error-value print function, the default value is `pprint`
+ ;; Set an error-value print function, the default value is `pprint`
  ;; :format {:error-value :pprint}
 
  :deps [[clj-hgvs "0.4.0"]]}

--- a/src/cruler/config.clj
+++ b/src/cruler/config.clj
@@ -6,7 +6,8 @@
   {:validators {}
    :paths ["validator"]
    :deps []
-   :colorize true})
+   :colorize true
+   :format {:error-value :pprint}})
 
 (def colorize
   (atom true))

--- a/src/cruler/core.clj
+++ b/src/cruler/core.clj
@@ -71,6 +71,14 @@
 (defn- pprint-str [x]
   (pprint/write x :stream nil))
 
+(def ^:private shape-type
+  (atom :pprint))
+
+(defn- shape-str [x]
+  (case @shape-type
+    :print (print-str x)
+    (pprint-str x)))
+
 (defn- indent [s n]
   (->> (string/split-lines s)
        (map #(str (apply str (repeat n " ")) %))
@@ -81,16 +89,16 @@
          (str (:pred err))
          (str (apply list (:pred err))))
        \newline
-       (indent (pprint-str (:val err)) 4)))
+       (indent (shape-str (:val err)) 4)))
 
 (defn- error-value-message
   [error-value]
   (if (sp/spec-problem? error-value)
     (if-let [readable-error (sp/readable-error error-value)]
       (str (apply str readable-error) \newline
-           (indent (pprint-str (:val error-value)) 4))
+           (indent (shape-str (:val error-value)) 4))
       (build-error-str error-value))
-    (pprint-str error-value)))
+    (shape-str error-value)))
 
 (defn- calc-range
   [line-num content num]
@@ -236,4 +244,5 @@
     (classpath/add-classpaths dir (:paths config))
     (classpath/add-deps (:deps config))
     (reset! config/colorize (:colorize config))
+    (reset! shape-type (get-in config [:format :error-value]))
     [absolute-filepath config]))


### PR DESCRIPTION
Because the error messages is only string, I think `print-str` looks better than `pprint-str`.
For example, when an error message has `\n` :

```
user=> (clojure.pprint/pprint "aaa\nbbb")
"aaa\nbbb"
nil
user=> (print "aaa\nbbb")
aaa
bbbnil
```

`"aaa\nbbb"` has raw `\n` instead of newline, but I'd like to show newline on messages.