### PR TITLE
Build for arm64 arch and release 1.2.1

### DIFF
--- a/.github/workflows/deploy-dockerhub.yml
+++ b/.github/workflows/deploy-dockerhub.yml
@@ -2,7 +2,9 @@
 
 name: deploy-dockerhub
 
-on: [workflow_dispatch]
+on:
+  push:
+    tags: ['*']
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-dockerhub.yml
+++ b/.github/workflows/deploy-dockerhub.yml
@@ -1,21 +1,50 @@
+---
+
 name: deploy-dockerhub
-on: [ workflow_dispatch ]
+
+on: [workflow_dispatch]
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
-      - name: get tag version
-        id: get_tag_version
-        run: |
-          sudo apt-get install libxml2-utils
-          echo ::set-output \
-            name=VERSION::$(xmllint --xpath "/*[local-name()='project']/*[local-name()='version']/text()" pom.xml)
-      - name: docker push
-        uses: docker/build-push-action@v1
+        uses: actions/checkout@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: xcoo/cruler
-          tags: ${{ steps.get_tag_version.outputs.VERSION }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Context for Buildx
+        run: |
+          docker context create mybuilder
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          endpoint: mybuilder
+
+      - name: Setup Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            name=xcoo/cruler
+          flavor: |
+            latest=${{ github.ref == 'refs/heads/master' }}
+          tags: |
+            type=ref,event=branch
+            type=pep440,pattern={{version}}
+
+      - name: Build image and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ You can use the docker image on [DockerHub/cruler](https://hub.docker.com/r/xcoo
 
 ```console
 # Specify image tag
-$ TAG=1.2.0
+$ TAG=1.2.1
 $ docker pull xcoo/cruler:${TAG}
 
 # Run validation

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>xcoo</groupId>
   <artifactId>cruler</artifactId>
-  <version>1.2.0</version>
+  <version>1.2.1</version>
   <name>cruler</name>
   <url>http://github.com/xcoo/cruler</url>
   <licenses>


### PR DESCRIPTION
For Apple M1/2 users, I updated the docker deployment configuration to support arm64 architecture using Docker buiidx.

And sorry, but I am in a bit of a hurry and have released 1.2.1. You can ensure it works fine if you see both amd64 and arm64 architecture images of version 1.2.1 are available on https://hub.docker.com/r/xcoo/cruler/tags.