### PR TITLE
Return nil when parsing empty YAML

### DIFF
--- a/dev-resources/sample-validator/drug/empty.yml
+++ b/dev-resources/sample-validator/drug/empty.yml
@@ -1,0 +1,2 @@
+# - id: foo
+#   name: drugA

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>xcoo</groupId>
   <artifactId>cruler</artifactId>
-  <version>1.2.1</version>
+  <version>1.2.2-SNAPSHOT</version>
   <name>cruler</name>
   <url>http://github.com/xcoo/cruler</url>
   <licenses>

--- a/src/cruler/parser.clj
+++ b/src/cruler/parser.clj
@@ -49,6 +49,9 @@
 (defn parse-yaml [s]
   (let [data (try
                (yaml/parse-string s :mark true)
+               (catch NullPointerException e
+                 (when-not s
+                   (throw e)))
                (catch Throwable e e))]
     (if (instance? Throwable data)
       data

--- a/test/cruler/parser_test.clj
+++ b/test/cruler/parser_test.clj
@@ -20,13 +20,18 @@
                                                {:line 0, :column 2}]}
       1 {:line 1, :column 0, :children-starts [{:line 1, :column 0}
                                                {:line 1, :column 1}]}
-      2 {:line 2, :column 0, :children-starts [{:line 2, :column 0}]})))
+      2 {:line 2, :column 0, :children-starts [{:line 2, :column 0}]}))
+
+  (is (= (parser/parse-csv "") []))
+
+  (is (thrown? Exception (parser/parse-csv nil))))
 
 (def sample-text
-  "I have a pen 
+  "I have a pen
 I love you
 
 gacha")
+
 (deftest parse-text-test
   (let [parsed (parser/parse-text sample-text)]
     (is (= parsed [["I" "have" "a" "pen"]
@@ -42,7 +47,11 @@ gacha")
                                                {:line 1, :column 1}
                                                {:line 1, :column 2}]}
       2 {:line 2, :column 0, :children-starts [{:line 2, :column 0}]}
-      3 {:line 3, :column 0, :children-starts [{:line 3, :column 0}]})))
+      3 {:line 3, :column 0, :children-starts [{:line 3, :column 0}]}))
+
+  (is (= (parser/parse-text "") [[""]]))
+
+  (is (thrown? Exception (parser/parse-text nil))))
 
 (def sample-yaml
   "- a: foo
@@ -72,4 +81,9 @@ gacha")
                                   {:line 4, :index 45, :column 6}]}
       [1 :b 0] {:line 9, :index 86, :column 6
                 :children-starts {:c {:line 9, :index 86, :column 6}
-                                  :d {:line 10, :index 97, :column 6}}})))
+                                  :d {:line 10, :index 97, :column 6}}}))
+
+  (is (nil? (parser/parse-yaml "")))
+  (is (nil? (parser/parse-yaml "# comment only\n# yaml file")))
+
+  (is (thrown? Exception (parser/parse-yaml nil))))


### PR DESCRIPTION
The current cruler returns an error object as `:parsed-content` when parsing an empty YAML or a comment-only YAML.

```clojure
;; master branch
(require '[cruler.parser :as parser])

(parser/parse-yaml "")
;;=> #error{:via [{:type java.lang.NullPointerException ...}] ...}

(parser/parse-yaml "# comment only\n# yaml file")
;;=> #error{:via [{:type java.lang.NullPointerException ...}] ...}
```

This is because `clj-yaml.core/parse-string` with `:mark true` option throws the exception when it cannot find the first node.
In contrast, `clj-yaml.core/parse-string` **without** `:mark true` returns `nil` in that case.

```clojure
(clj-yaml.core/parse-string "" :mark true)
;;=> NullPointerException

(clj-yaml.core/parse-string "")
;;=> nil
```

Additionally, other cruler's parsers, `parse-csv` and `parse-text`, returns an empty data instead of the error object.

This PR has fixed the inconsistency and improved usability on user side.
Particularly, the comment-only YAML file containing a template is sometimes used for indicating the format.

```clojure
;; PR branch
(parser/parse-yaml "")
;;=> nil

(parser/parse-yaml "# comment only\n# yaml file")
;;=> nil
```