### PR TITLE
Deploy multi-arch snapshot image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,17 +63,45 @@ jobs:
   # ref: https://docs.github.com/en/free-pro-team@latest/actions/guides/publishing-docker-images
   # You can find the image on: https://hub.docker.com/r/xcoo/cruler
   deploy-dockerhub-snapshot:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: ${{ github.event_name == 'push' &&
+            github.ref == 'refs/heads/main' &&
+            endsWith(needs.get-version.outputs.version, '-SNAPSHOT') }}
     needs: [test, validate, lint, get-version]
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
-      - name: snapshot push
-        if: endsWith(needs.get-version.outputs.version, '-SNAPSHOT')
-        uses: docker/build-push-action@v1
+        uses: actions/checkout@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: xcoo/cruler
-          tags: ${{ needs.get-version.outputs.version }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Context for Buildx
+        run: |
+          docker context create mybuilder
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          endpoint: mybuilder
+
+      - name: Setup Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            name=xcoo/cruler
+          tags: |
+            ${{ needs.get-version.outputs.version }}
+
+      - name: Build image and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Actions will deploy multi-arch (amd64, arm64) docker image of `-SNAPSHOT` version like #17.

The operation has been confirmed in https://github.com/xcoo/cruler/actions/runs/4231256904.