### PR TITLE
Fix blank-line validator

### DIFF
--- a/test/cruler/validators_test.clj
+++ b/test/cruler/validators_test.clj
@@ -71,6 +71,11 @@
                               (list {:raw-content "ABC\nDEF\n"
                                      :parsed-content (parser/parse-text "ABC\nDEF\n")
                                      :file-path "a.txt"
+                                     :file-type :text})))))
+      (t/is (empty? (:errors (validate
+                              (list {:raw-content "ABC\nDE  F\n"
+                                     :parsed-content (parser/parse-text "ABC\nDE  F\n")
+                                     :file-path "a.txt"
                                      :file-type :text}))))))
     (t/testing "blank line"
       (t/testing "single file"


### PR DESCRIPTION
The current `:cruler.validators/blank-line` validator changed by #6 wrongly raises an error when the following file is provided.

```
ABC
DE  F
```

To be precise, implementation of the current `:cruler.validators/blank-line` validator is "blank-column" not "blank-line".

Additionally, the `:cruler.validators/blank-line` validator is a general validator and should not limit file type to `:csv` and `:text`.

I have fixed the above problems.